### PR TITLE
fix: :bug: Timestamp the cache query key

### DIFF
--- a/lib/queryKeys.ts
+++ b/lib/queryKeys.ts
@@ -8,5 +8,5 @@ export const memberQueryKey = (member: GetMembersType) =>
 // This section is for the query keys used in marketingAI project requests
 export const marketingAIQueryKey = "marketingAI";
 export const marketingAIQueryKeys = (prompt: GenerateImageParams) => {
-  return "marketingAI: " + prompt?.prompt;
+  return "marketingAI: " + prompt?.prompt + ". Timestamp: " + prompt?.timestamp;
 };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -25,6 +25,7 @@ export type GenerateImageParams = {
   prompt: string;
   width: number;
   height: number;
+  timestamp: string;
 };
 
 export type MarketingAIResponse = {

--- a/pages/projects/marketingai.tsx
+++ b/pages/projects/marketingai.tsx
@@ -24,6 +24,7 @@ const MarketingAI = () => {
       prompt: value,
       width: 1024,
       height: 1024,
+      timestamp: Date.now().toString(),
     };
 
     setParams(params);


### PR DESCRIPTION
Timestamp the cache query key on the request, so that each of the requests have their own unique cache key

fix for #33