### PR TITLE
fix(#26): make projects clickable on HomeP2 

### DIFF
--- a/components/Home/HomeP2.tsx
+++ b/components/Home/HomeP2.tsx
@@ -13,7 +13,7 @@ import Button from "../Buttons/Button";
 const HomeP2 = () => {
   return (
     <div className="relative h-full w-full overflow-hidden">
-      <div className="absolute w-full h-full bg-gradient-to-b to-transparent from-blue-dark from-0% to-30% z-50"></div>
+      <div className="absolute w-full h-full bg-gradient-to-b to-transparent from-blue-dark from-0% to-30% z-50 pointer-events-none"></div>
       <div className="absolute w-full h-full laptop:block hidden">
         <Image
           priority={true}


### PR DESCRIPTION
I found the solution! The issue was resolved by adding pointer-events: none; to the gradient overlay. This CSS rule allows mouse events to pass through the overlay, making underlying elements, like the button, clickable:

```tsx
<div className="absolute w-full h-full bg-gradient-to-b to-transparent from-blue-dark from-0% to-30% z-50 pointer-events-none"></div>
```
This adjustment ensures that the overlay remains visible for styling purposes but does not interfere with the interaction of elements below it.