### PR TITLE
fix: update intern hackathon description to focus on project kickstart

### DIFF
--- a/data/events.ts
+++ b/data/events.ts
@@ -107,7 +107,7 @@ export const hardcodedEvents: Array<EventType> = [
     date: new Date("2025-09-27"),
     timeString: "27.09",
     subTimeString: "lørdag",
-    location: "TBA",
+    location: "Rom 04-025, Helgasetr",
     description:
       "En hel dag med koding, kreativitet og kaffe! Vårt interne hackathon hvor hele Cogito får en kickstart på prosjektene, og blir bedre kjent på tvers av gruppene. Premier, pizza og mye moro!",
     image: InterntHackathon,

--- a/data/events.ts
+++ b/data/events.ts
@@ -109,7 +109,7 @@ export const hardcodedEvents: Array<EventType> = [
     subTimeString: "lørdag",
     location: "TBA",
     description:
-      "En hel dag med koding, kreativitet og kaffe! Vårt interne hackathon hvor Cogito-medlemmer konkurrerer i lag for å skape innovative løsninger. Premier, pizza og mye moro!",
+      "En hel dag med koding, kreativitet og kaffe! Vårt interne hackathon hvor hele Cogito får en kickstart på prosjektene, og blir bedre kjent på tvers av gruppene. Premier, pizza og mye moro!",
     image: InterntHackathon,
   },
   {


### PR DESCRIPTION
## Summary
• Updated internal hackathon description to emphasize project kickstart and cross-group networking
• Changed from competition-focused language to collaboration and team building focus
• Better reflects the event's purpose of helping members get started on projects

## Test plan
- [ ] Verify the calendar page displays the updated description correctly
- [ ] Check that the event information is accurate and clear

🤖 Generated with [Claude Code](https://claude.ai/code)